### PR TITLE
Save endpoint to bash [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,16 @@ jobs:
           service-name: "example-service"
           region: "us-east1"
           unauthenticated: true
+      - run:
+          name: Test managed deployed service.
+          command: |
+            GCP_API_RESULTS=$(curl -s "$GCP_DEPLOY_ENDPOINT")
+            if [ "$GCP_API_RESULTS" != "Hello World!" ]; then
+              echo "Result is unexpected"
+              echo 'Result: '
+              curl -s "$GCP_DEPLOY_ENDPOINT"
+              exit 1;
+            fi
 
 workflows:
   # this `lint-pack_validate_publish-dev` workflow will run on any commit

--- a/README.md
+++ b/README.md
@@ -4,4 +4,6 @@ Easily add [Google Cloud Run](https://cloud.google.com/run/) deployments to your
 
 Full documentation: https://circleci.com/orbs/registry/orb/circleci/gcp-cloud-run
 
+Want to see simplified live example getting-started project? Check this out!: https://github.com/CircleCI-Public/gcp-cloud-run-sample-project
+
 Learn more about [Orbs](https://circleci.com/docs/2.0/using-orbs/ "Using Orbs").

--- a/src/commands/deploy.yml
+++ b/src/commands/deploy.yml
@@ -62,7 +62,9 @@ steps:
             <<^ parameters.unauthenticated>>--no-allow-unauthenticated<</parameters.unauthenticated>> \
             --platform managed
 
-            GCP_DEPLOY_ENDPOINT=$(gcloud beta run services describe <<parameters.service-name>> --platform <<parameters.platform>><<# parameters.region>> --region <<parameters.region>><</ parameters.region>> --format="value(status.address.url)")
+            GET_GCP_DEPLOY_ENDPOINT=$(gcloud beta run services describe <<parameters.service-name>> --platform <<parameters.platform>><<# parameters.region>> --region <<parameters.region>><</ parameters.region>> --format="value(status.address.url)")
+            echo "export GCP_DEPLOY_ENDPOINT=$GET_GCP_DEPLOY_ENDPOINT" >> $BASH_ENV
+            source $BASH_ENV
             echo $GCP_DEPLOY_ENDPOINT
             ;;
           gke)

--- a/src/commands/deploy.yml
+++ b/src/commands/deploy.yml
@@ -1,6 +1,7 @@
 # How to author commands: https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-commands
 description: >
-  'Deploy your containerized application to Google Cloud Run. Learn more: https://cloud.google.com/run/docs/deploying'
+  'Deploy your containerized application to Google Cloud Run. Learn more: https://cloud.google.com/run/docs/deploying
+  For the managed service: After deployment, the service URL will be accessible via the $GCP_DEPLOY_ENDPOINT environment variable.'
 parameters:
   platform:
     type: enum

--- a/src/commands/deploy.yml
+++ b/src/commands/deploy.yml
@@ -61,7 +61,9 @@ steps:
             <<# parameters.unauthenticated>>--allow-unauthenticated<</parameters.unauthenticated>> \
             <<^ parameters.unauthenticated>>--no-allow-unauthenticated<</parameters.unauthenticated>> \
             --platform managed
-
+            echo
+            echo "Service deployed"
+            echo
             GET_GCP_DEPLOY_ENDPOINT=$(gcloud beta run services describe <<parameters.service-name>> --platform <<parameters.platform>><<# parameters.region>> --region <<parameters.region>><</ parameters.region>> --format="value(status.address.url)")
             echo "export GCP_DEPLOY_ENDPOINT=$GET_GCP_DEPLOY_ENDPOINT" >> $BASH_ENV
             source $BASH_ENV
@@ -91,8 +93,8 @@ steps:
             --cluster-location <<parameters.cluster-location>> \
             --image <<parameters.image>> \
             --platform gke
-
-            GCP_DEPLOY_ENDPOINT=$(gcloud container clusters describe <<parameters.cluster>>)
-            echo $GCP_DEPLOY_ENDPOINT
+            echo
+            echo "Service deployed"
+            echo
             ;;
         esac

--- a/src/examples/build_and_deploy_on_managed.yml
+++ b/src/examples/build_and_deploy_on_managed.yml
@@ -19,6 +19,18 @@ usage:
             service-name: "example-service"
             region: "us-east1"
             unauthenticated: true
+        - run:
+          name: Test managed deployed service.
+          command: |
+            # A simple example of how a deployed managed service could be verified or further tested.
+            # This step will send request our "API" and fail if there is unexpected output.
+            GCP_API_RESULTS=$(curl -s "$GCP_DEPLOY_ENDPOINT")
+            if [ "$GCP_API_RESULTS" != "Hello World!" ]; then
+              echo "Result is unexpected"
+              echo 'Result: '
+              curl -s "$GCP_DEPLOY_ENDPOINT"
+              exit 1;
+            fi
   workflows:
     build_and_deploy_to_managed_workflow:
       jobs:

--- a/src/examples/build_and_deploy_on_managed.yml
+++ b/src/examples/build_and_deploy_on_managed.yml
@@ -20,17 +20,17 @@ usage:
             region: "us-east1"
             unauthenticated: true
         - run:
-          name: Test managed deployed service.
-          command: |
-            # A simple example of how a deployed managed service could be verified or further tested.
-            # This step will send request our "API" and fail if there is unexpected output.
-            GCP_API_RESULTS=$(curl -s "$GCP_DEPLOY_ENDPOINT")
-            if [ "$GCP_API_RESULTS" != "Hello World!" ]; then
-              echo "Result is unexpected"
-              echo 'Result: '
-              curl -s "$GCP_DEPLOY_ENDPOINT"
-              exit 1;
-            fi
+            name: Test managed deployed service.
+            command: |
+              # A simple example of how a deployed managed service could be verified or further tested.
+              # This step will send request our "API" and fail if there is unexpected output.
+              GCP_API_RESULTS=$(curl -s "$GCP_DEPLOY_ENDPOINT")
+              if [ "$GCP_API_RESULTS" != "Hello World!" ]; then
+                echo "Result is unexpected"
+                echo 'Result: '
+                curl -s "$GCP_DEPLOY_ENDPOINT"
+                exit 1;
+              fi
   workflows:
     build_and_deploy_to_managed_workflow:
       jobs:


### PR DESCRIPTION
All managed deployments will be accessible via the $GCP_DEPLOY_ENDPOINT environment variable.