### PR TITLE
Incorrect command naming in  examples

### DIFF
--- a/src/examples/build_and_deploy_on_gke.yml
+++ b/src/examples/build_and_deploy_on_gke.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cloudrun: circleci/gcp-cloud-run@x.y
+    gcp-cloud-run: circleci/gcp-cloud-run@x.y
   jobs:
     build_and_deploy_gke:
       docker:

--- a/src/examples/build_and_deploy_on_gke.yml
+++ b/src/examples/build_and_deploy_on_gke.yml
@@ -10,16 +10,16 @@ usage:
         - image: cimg/base:stable
       steps:
         - checkout
-        - cloudrun/init
-        - cloudrun/create_gke_cluster:
+        - gcp-cloud-run/init
+        - gcp-cloud-run/create_gke_cluster:
             cluster-name: "example-cluster-${CIRCLE_BUILD_NUM}"
             machine-type: "n1-standard-4"
             zone: "us-east1"
             enable-stackdriver-kubernetes: true
             scopes: "cloud-platform"
-        - cloudrun/build:
+        - gcp-cloud-run/build:
             tag: "gcr.io/${GOOGLE_PROJECT_ID}/test-${CIRCLE_SHA1}"
-        - cloudrun/deploy:
+        - gcp-cloud-run/deploy:
             platform: "gke"
             cluster: "example-cluster-${CIRCLE_BUILD_NUM}"
             image: "gcr.io/${GOOGLE_PROJECT_ID}/test-${CIRCLE_SHA1}"

--- a/src/examples/build_and_deploy_on_managed.yml
+++ b/src/examples/build_and_deploy_on_managed.yml
@@ -10,10 +10,10 @@ usage:
         - image: cimg/base:stable
       steps:
         - checkout
-        - cloudrun/init
-        - cloudrun/build:
+        - gcp-cloud-run/init
+        - gcp-cloud-run/build:
             tag: "gcr.io/${GOOGLE_PROJECT_ID}/test-${CIRCLE_SHA1}"
-        - cloudrun/deploy:
+        - gcp-cloud-run/deploy:
             platform: managed
             image: "gcr.io/${GOOGLE_PROJECT_ID}/test-${CIRCLE_SHA1}"
             service-name: "example-service"

--- a/src/examples/build_and_deploy_on_managed.yml
+++ b/src/examples/build_and_deploy_on_managed.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cloudrun: circleci/gcp-cloud-run@x.y
+    gcp-cloud-run: circleci/gcp-cloud-run@x.y
   jobs:
     build_and_deploy:
       docker:


### PR DESCRIPTION
There was a mistake in the command naming in the examples. Should be gcp-cloud-run instead of cloudrun. 

Will this correction go into offical circle ci docs?
-> https://github.com/circleci/circleci-docs/issues/4231

Tim