### PR TITLE
[semver:minor] Use `gcloud run` instead of `gcloud beta run` after GA

### DIFF
--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -17,7 +17,7 @@ parameters:
   args:
     type: string
     default: ""
-    description: "Add any additional arguments not explicitly defined as a parameter. Find additional arguments here: https://cloud.google.com/sdk/gcloud/reference/beta/builds/submit"
+    description: "Add any additional arguments not explicitly defined as a parameter. Find additional arguments here: https://cloud.google.com/sdk/gcloud/reference/builds/submit"
 steps:
   - run:
       name: "Cloud Run Build"

--- a/src/commands/create_gke_cluster.yml
+++ b/src/commands/create_gke_cluster.yml
@@ -29,14 +29,14 @@ parameters:
   args:
     type: string
     default: ""
-    description: "Add any additional arguments not explicitly defined as a parameter. Find additional arguments here: https://cloud.google.com/sdk/gcloud/reference/beta/container/clusters/create#--enable-stackdriver-kubernetes"
+    description: "Add any additional arguments not explicitly defined as a parameter. Find additional arguments here: https://cloud.google.com/sdk/gcloud/reference/container/clusters/create#--enable-stackdriver-kubernetes"
 steps:
   - run:
       name: "Create GKE Cluster"
       command: |
               gcloud config set run/platform gke
               gcloud config set project $GOOGLE_PROJECT_ID
-              gcloud beta container clusters create <<parameters.cluster-name>> \
+              gcloud container clusters create <<parameters.cluster-name>> \
               --addons=<<parameters.addons>> \
               --machine-type=<<parameters.machine-type>> \
               --zone=<<parameters.zone>> \

--- a/src/commands/delete_gke_cluster.yml
+++ b/src/commands/delete_gke_cluster.yml
@@ -12,7 +12,7 @@ parameters:
   args:
     type: string
     default: ""
-    description: "Add any additional arguments not explicitly defined as a parameter. Find additional arguments here: https://cloud.google.com/sdk/gcloud/reference/beta/container/clusters/create#--enable-stackdriver-kubernetes"
+    description: "Add any additional arguments not explicitly defined as a parameter. Find additional arguments here: https://cloud.google.com/sdk/gcloud/reference/container/clusters/create#--enable-stackdriver-kubernetes"
 steps:
   - run:
       name: "Delete GKE Cluster"

--- a/src/commands/deploy.yml
+++ b/src/commands/deploy.yml
@@ -30,7 +30,7 @@ parameters:
   args:
     type: string
     default: ""
-    description: "Add any additional arguments not explicitly defined as a parameter. Find additional arguments here: https://cloud.google.com/sdk/gcloud/reference/beta/run/deploy"
+    description: "Add any additional arguments not explicitly defined as a parameter. Find additional arguments here: https://cloud.google.com/sdk/gcloud/reference/run/deploy"
   unauthenticated:
     type: boolean
     default: false
@@ -56,7 +56,7 @@ steps:
             fi
             # End of parameter check
             # Deployment command
-            gcloud beta run deploy <<parameters.service-name>> \
+            gcloud run deploy <<parameters.service-name>> \
             --image <<parameters.image>> \
             --region <<parameters.region>> \
             <<# parameters.unauthenticated>>--allow-unauthenticated<</parameters.unauthenticated>> \
@@ -65,7 +65,7 @@ steps:
             echo
             echo "Service deployed"
             echo
-            GET_GCP_DEPLOY_ENDPOINT=$(gcloud beta run services describe <<parameters.service-name>> --platform <<parameters.platform>><<# parameters.region>> --region <<parameters.region>><</ parameters.region>> --format="value(status.address.url)")
+            GET_GCP_DEPLOY_ENDPOINT=$(gcloud run services describe <<parameters.service-name>> --platform <<parameters.platform>><<# parameters.region>> --region <<parameters.region>><</ parameters.region>> --format="value(status.address.url)")
             echo "export GCP_DEPLOY_ENDPOINT=$GET_GCP_DEPLOY_ENDPOINT" >> $BASH_ENV
             source $BASH_ENV
             echo $GCP_DEPLOY_ENDPOINT
@@ -89,7 +89,7 @@ steps:
             echo
             gcloud services enable container.googleapis.com containerregistry.googleapis.com cloudbuild.googleapis.com
             echo
-            gcloud beta run deploy <<parameters.service-name>>\
+            gcloud run deploy <<parameters.service-name>>\
             --cluster <<parameters.cluster>> \
             --cluster-location <<parameters.cluster-location>> \
             --image <<parameters.image>> \

--- a/src/commands/init.yml
+++ b/src/commands/init.yml
@@ -20,3 +20,6 @@ steps:
       gcloud-service-key: <<parameters.gcloud-service-key>>
       google-compute-zone: <<parameters.google-compute-zone>>
       google-project-id: <<parameters.google-project-id>>
+  - run:
+      name: "Prep Cloud Run components"
+      command: gcloud components update

--- a/src/commands/init.yml
+++ b/src/commands/init.yml
@@ -20,6 +20,3 @@ steps:
       gcloud-service-key: <<parameters.gcloud-service-key>>
       google-compute-zone: <<parameters.google-compute-zone>>
       google-project-id: <<parameters.google-project-id>>
-  - run:
-      name: "Prep Cloud Run components"
-      command: gcloud components install beta && gcloud components update # Nov 12th 2019, switch to component update only.


### PR DESCRIPTION
GCP Cloud run had been already GA in December 2019
https://cloud.google.com/run/docs/release-notes

Therefore, there's no need to install / use beta command
https://cloud.google.com/sdk/gcloud/reference/run